### PR TITLE
Remove most warnings from files belonging to EML

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/parity/client/CtsBridge.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/CtsBridge.java
@@ -16,47 +16,14 @@
 
 package com.paritytrading.parity.client;
 
-import com.paritytrading.parity.client.TerminalClient.*;
-import com.paritytrading.parity.client.EnterCommand.*;
-
-import com.paritytrading.foundation.ASCII;
 import com.paritytrading.parity.net.poe.POE;
 import com.paritytrading.parity.util.Instrument;
 import com.paritytrading.parity.util.Instruments;
 import java.io.IOException;
-import java.nio.channels.ClosedChannelException;
-import java.util.NoSuchElementException;
-import java.util.Scanner;
 
 import java.util.Random;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.*;
-import com.fasterxml.jackson.datatype.jsr310.*;
-
-import java.util.concurrent.atomic.AtomicLong;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Iterator;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-//	import org.apache.logging.log4j.LogManager;
-//	import org.apache.logging.log4j.Logger;
-
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.AbstractQueue;
-import java.util.AbstractCollection;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ArrayBlockingQueue;
 
 /*
@@ -103,9 +70,9 @@ class CtsBridge extends Thread {
 	
 	public CtsBridge(TerminalClient client, Events events, Instruments instruments)	{
 		// store information needed to call EnterCommand.bridgeExecute() to enter orders
-		this.client = client;
 		this.events = events;
-		this.instruments = instruments;
+		CtsBridge.client = client;
+		CtsBridge.instruments = instruments;
 	}
 
 	// set by TerminalClient call to this.setSide()
@@ -152,11 +119,6 @@ class CtsBridge extends Thread {
 	private Instrument localInstrument;
 	private static long[] quantity = new long[10];
 	private static long[] price = new long[10];
-	private static MarketCreateTenderPayload[] createTenderPayload = 
-					new MarketCreateTenderPayload[10];
-	private static String[] json = new String[10];
-	private static MarketCreateTenderPayload[] deserializedTenderPayload = 
-					new MarketCreateTenderPayload[10];	
 	private static String[] orderIds = new String[10];
 	
 	// for randomized quantity and price
@@ -426,7 +388,7 @@ class CtsBridge extends Thread {
 	}
 	
 	public void setClient(TerminalClient client) {
-		this.client = client;
+		CtsBridge.client = client;
 	}
 	
 	public EnterCommand getBuySide() {
@@ -434,7 +396,7 @@ class CtsBridge extends Thread {
 	}
 	
 	public void setBuySide(EnterCommand buyCmd) {
-		this.buySide = buyCmd;
+		CtsBridge.buySide = buyCmd;
 	}
 	
 	public EnterCommand getSellSide() {
@@ -442,7 +404,7 @@ class CtsBridge extends Thread {
 	}
 	
 	public void setSellSide(EnterCommand sellCmd) {
-		this.sellSide = sellCmd;
+		CtsBridge.sellSide = sellCmd;
 	}
 	
 	public Instruments getInstruments() {
@@ -450,7 +412,7 @@ class CtsBridge extends Thread {
 	}
 	
 	public void setInstruments(Instruments instruments) {
-		this.instruments = instruments;
+		CtsBridge.instruments = instruments;
 	}
 
 //	/*

--- a/applications/client/src/main/java/com/paritytrading/parity/client/CtsSocketClient.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/CtsSocketClient.java
@@ -23,18 +23,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ArrayBlockingQueue;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Iterator;
-import java.util.Set;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /*
@@ -65,7 +54,6 @@ public class CtsSocketClient	extends Thread {
 
 	private Socket clientSocket;
 	private PrintWriter out;
-	private static InputStreamReader inStream;
 	private BufferedReader in;
 	
 	public static final int MARKET_PORT = 39402;
@@ -73,7 +61,6 @@ public class CtsSocketClient	extends Thread {
 	
 	private static int port = LME_PORT;	// CreateTransaction from Market to LME
 	private static String ip = "127.0.0.1";	
-	private static String hostName = "localhost";
 	CtsBridge bridge;	// to access bridge.createTransactionQueue
 	
 	public CtsSocketClient()	{
@@ -85,7 +72,7 @@ public class CtsSocketClient	extends Thread {
 //    	System.err.println("CtsSocketClient: constructor 2 parameters bridge port " +
 //    			port + " ip " + ip + " " + Thread.currentThread().getName());
     	this.bridge = bridge;
-    	this.port = port;
+    	CtsSocketClient.port = port;
     	if (bridge == null)	{
     		System.err.println("CtsSocketClient: constructor:this.bridge is null");
     	}
@@ -95,8 +82,6 @@ public class CtsSocketClient	extends Thread {
 	public void run() {
 		MarketCreateTransactionPayload createTransaction;
 		String jsonString = null;	// for JSON string
-		boolean tryingToCreateSocket = true;
-		long retryCount = 0;
 		
 // 		System.err.println("CtsSocketClient.run() port: " + port +
 // 				" ip " + ip + " " + Thread.currentThread().getName());
@@ -135,7 +120,7 @@ public class CtsSocketClient	extends Thread {
 //              	bridge.createTransactionQueue.size() + " " +
 //              	Thread.currentThread().getName());
               	
-              	createTransaction = bridge.createTransactionQueue.take();
+              	createTransaction = CtsBridge.createTransactionQueue.take();
               	
 //              System.err.println(
 //              	"CtsSocketClient.run after bridge.createTransactionQueue.take size " +

--- a/applications/client/src/main/java/com/paritytrading/parity/client/CtsSocketServer.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/CtsSocketServer.java
@@ -16,26 +16,11 @@
 
 package com.paritytrading.parity.client;
 
-import com.paritytrading.parity.client.TerminalClient.*;
-import com.paritytrading.parity.client.EnterCommand.*;
-
 import java.net.*;
 import java.io.*;
-import java.lang.Runnable;
 import java.lang.Thread;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.ser.std.*;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.AbstractQueue;
-import java.util.AbstractCollection;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ArrayBlockingQueue;
 
 //import java.util.HashMap;
 //import java.util.Map;
@@ -145,7 +130,7 @@ public class CtsSocketServer extends Thread	{
 //    	System.err.println(
 //    		"CtsSocketServer: constructor 1 arg port: " + port + " " +
 //    		Thread.currentThread().getName() );
-    	this.port = port;
+    	CtsSocketServer.port = port;
     	
     	CtsSocketServer server = new CtsSocketServer();	
     	// TODO Lambda Expression for separate thread - current is in thread
@@ -155,7 +140,7 @@ public class CtsSocketServer extends Thread	{
 //    	System.err.println("CtsSocketServer: constructor bridge and Port: " 
 //    			+ port + " " + Thread.currentThread().getName() );
     	this.bridge = bridge;
-    	this.port = port;
+    	CtsSocketServer.port = port;
     	if (bridge == null)	{
     		System.err.println("CtsSocketServer: constructor:this.bridge is null");
     	}

--- a/applications/client/src/main/java/com/paritytrading/parity/client/Events.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/Events.java
@@ -36,8 +36,6 @@ import com.paritytrading.parity.net.poe.POEClientListener;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.paritytrading.parity.client.*;
-
 /*
  *	WTC
  *	Changed to allow hooks for CtsBridge to emit EiCreateTransaction

--- a/applications/client/src/main/java/com/paritytrading/parity/client/MarketCreateTenderPayload.java
+++ b/applications/client/src/main/java/com/paritytrading/parity/client/MarketCreateTenderPayload.java
@@ -16,11 +16,7 @@
 
 package com.paritytrading.parity.client;
 
-import java.time.Duration;
 import java.time.Instant;
-import java.time.*;
-
-import com.paritytrading.parity.client.CtsInterval;
 
 /*
  * Sent by the LME to the Market with information to be


### PR DESCRIPTION
Most warnings were from unused imports especially in files Cts*.java
Some were from fields needing to be accessed in a static way
I left files like the POM not belonging to EML alone